### PR TITLE
Fix issue with taking the underlying array from the write buffer.

### DIFF
--- a/src/main/java/com/github/sth/vertx/mongo/streams/GridFSOutputStreamImpl.java
+++ b/src/main/java/com/github/sth/vertx/mongo/streams/GridFSOutputStreamImpl.java
@@ -1,10 +1,13 @@
 package com.github.sth.vertx.mongo.streams;
 
 import com.mongodb.async.SingleResultCallback;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.streams.WriteStream;
 
 import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.WriteStream;
 
 public class GridFSOutputStreamImpl implements GridFSOutputStream {
 
@@ -16,13 +19,11 @@ public class GridFSOutputStreamImpl implements GridFSOutputStream {
 
     @Override
     public void write(ByteBuffer byteBuffer, SingleResultCallback<Integer> singleResultCallback) {
-
-        byte[] bytes = byteBuffer.array();
-        Buffer buffer = Buffer.buffer(bytes);
-
+        //  Buffer does not expose the internal ByteBuffer hence this is the only way to correctly set position and limit
+        final ByteBuf byteBuf = Unpooled.wrappedBuffer(byteBuffer); //  There is no copy of the backing array
+        final Buffer buffer = Buffer.buffer(byteBuf); //  There is no copy of the backing array
         writeStream.write(buffer);
-
-        singleResultCallback.onResult(bytes.length, null);
+        singleResultCallback.onResult(byteBuf.readableBytes(), null);
     }
 
     @Override

--- a/src/test/java/com/github/sth/vertx/mongo/streams/GridFSOutputStreamTest.java
+++ b/src/test/java/com/github/sth/vertx/mongo/streams/GridFSOutputStreamTest.java
@@ -2,24 +2,29 @@ package com.github.sth.vertx.mongo.streams;
 
 import com.github.sth.vertx.mongo.streams.util.ByteUtil;
 import com.github.sth.vertx.mongo.streams.util.ResultCallback;
-import io.vertx.core.Handler;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.streams.WriteStream;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.streams.WriteStream;
+
 public class GridFSOutputStreamTest {
 
+    private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024 * 4;
+
     /**
-     * Test that bytes are written to the provided WriteStream correctly and the callback returns the excepted result.
+     * Test that bytes are written to the provided WriteStream correctly and the callback returns
+     * the excepted result.
      */
     @Test
     public void happyPathWrite() {
 
-        byte [] bytes = ByteUtil.randomBytes(2048);
+        byte[] bytes = ByteUtil.randomBytes(2048);
         ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
         ResultCallback<Integer> resultCallback = new ResultCallback<>();
         WriteStreamMock writeStreamMock = new WriteStreamMock();
@@ -29,6 +34,28 @@ public class GridFSOutputStreamTest {
 
         Assert.assertTrue(resultCallback.succeeded());
         Assert.assertEquals(2048, resultCallback.getResult(), 0);
+        Assert.assertTrue(Arrays.equals(writeStreamMock.buffer.getBytes(), bytes));
+    }
+
+    /**
+     * Test that bytes are written to the provided WriteStream correctly and the callback returns
+     * the excepted result.
+     */
+    @Test
+    public void happyPathWriteWithNotAlignedBuffer() {
+
+        byte[] bytes = "123456789ABCDEF".getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE);
+        byteBuffer.put(bytes);
+        byteBuffer.flip();
+        ResultCallback<Integer> resultCallback = new ResultCallback<>();
+        WriteStreamMock writeStreamMock = new WriteStreamMock();
+        GridFSOutputStream outputStream = GridFSOutputStream.create(writeStreamMock);
+
+        outputStream.write(byteBuffer, resultCallback);
+
+        Assert.assertTrue(resultCallback.succeeded());
+        Assert.assertEquals(bytes.length, resultCallback.getResult(), 0);
         Assert.assertTrue(Arrays.equals(writeStreamMock.buffer.getBytes(), bytes));
     }
 


### PR DESCRIPTION
Fixes #3 
This will:
- Fix the way we copy the underlying byte[] we now take into account the current position
- Add a test to cover the issue