### PR TITLE
Fix visibility issue due to incomplete synchronisation

### DIFF
--- a/src/main/java/com/github/sth/vertx/mongo/streams/GridFSInputStream.java
+++ b/src/main/java/com/github/sth/vertx/mongo/streams/GridFSInputStream.java
@@ -35,4 +35,13 @@ public interface GridFSInputStream extends AsyncInputStream, WriteStream<Buffer>
   static GridFSInputStream create() {
     return new GridFSInputStreamImpl();
   }
+
+  /**
+   * Create a {@link com.github.sth.vertx.mongo.streams.GridFSInputStream}.
+   *
+   * @return the stream
+   */
+  static GridFSInputStream create(int queueSize) {
+    return new GridFSInputStreamImpl(queueSize);
+  }
 }

--- a/src/main/java/com/github/sth/vertx/mongo/streams/GridFSInputStreamImpl.java
+++ b/src/main/java/com/github/sth/vertx/mongo/streams/GridFSInputStreamImpl.java
@@ -1,13 +1,13 @@
 package com.github.sth.vertx.mongo.streams;
 
+import com.github.sth.vertx.mongo.streams.util.CircularByteBuffer;
 import com.mongodb.async.SingleResultCallback;
+
+import java.nio.ByteBuffer;
+
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.WriteStream;
-
-import java.nio.ByteBuffer;
-import java.util.ArrayDeque;
-import java.util.Queue;
 
 /**
  * <p>GridFSInputStreamImpl class.</p>
@@ -16,115 +16,123 @@ import java.util.Queue;
  */
 public class GridFSInputStreamImpl implements GridFSInputStream {
 
-  private int writeQueueMaxSize = 8192;
+    private int writeQueueMaxSize;
+    private final CircularByteBuffer buffer;
+    private Handler<Void> drainHandler;
+    private volatile boolean closed = false;
+    private SingleResultCallback<Integer> pendingCallback;
+    private ByteBuffer outputBuffer;
 
-  private final Queue<Byte> pending = new ArrayDeque<>();
-  private Handler<Void> drainHandler;
-
-  ByteBuffer outBuffer;
-  SingleResultCallback<Integer> callback;
-
-  boolean closed = false;
-
-  public void read(ByteBuffer byteBuffer, SingleResultCallback<Integer> singleResultCallback) {
-    this.writeBytes(byteBuffer, singleResultCallback);
-  }
-
-  public void close(SingleResultCallback<Void> singleResultCallback) {
-    callback.onResult(null, null);
-  }
-
-  public WriteStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
-    return this;
-  }
-
-  public WriteStream<Buffer> write(Buffer buffer) {
-    for (byte b : buffer.getBytes()) {
-      pending.add(b);
-    }
-    writeBytes(null, null);
-    return this;
-  }
-
-  public void end() {
-    this.closed = true;
-    // if there is no more data to write, call the callback immediately
-    if (this.pending.size() == 0 && this.callback != null) {
-      this.callback.onResult(-1, null);
-      this.callback = null;
-      this.outBuffer = null;
-    }
-  }
-
-  public GridFSInputStream setWriteQueueMaxSize(int i) {
-    this.writeQueueMaxSize = i;
-    return this;
-  }
-
-  public boolean writeQueueFull() {
-    return pending.size() >= writeQueueMaxSize;
-  }
-
-  public WriteStream<Buffer> drainHandler(Handler<Void> handler) {
-    this.drainHandler = handler;
-    return this;
-  }
-
-  /**
-   * Write bytes to the buffer provided by the mongo driver. Buffer and Callback provided are cached in case no data
-   * is available to write and will be fulfilled by future invocations.
-   * @param b optional buffer provided by the mongo driver
-   * @param c optional callback provided by the mongo driver
-   */
-  private synchronized void writeBytes(ByteBuffer b, SingleResultCallback<Integer> c) {
-    int bytesWritten = 0;
-
-    if (b != null && c != null) {
-      if (this.outBuffer != null || this.callback != null) {
-        c.onResult(null, new RuntimeException("mongo provided a new buffer or callback before the previous " +
-            "one has been fulfilled"));
-      }
-      this.outBuffer = b;
-      this.callback = c;
+    public GridFSInputStreamImpl() {
+        buffer = new CircularByteBuffer(8192);
+        writeQueueMaxSize = buffer.capacity();
     }
 
-    // a callback and a buffer to write to is available
-    if (this.outBuffer != null && this.callback != null) {
+    public GridFSInputStreamImpl(final int queueSize) {
+        buffer = new CircularByteBuffer(queueSize);
+        writeQueueMaxSize = queueSize;
+    }
 
-      // there is space in the out buffer available and we have some data to write left, so we write it to the buffer
-      if (this.outBuffer.remaining() > 0 && this.pending.size() > 0) {
-
-        int bytesToWrite = Math.min(this.outBuffer.remaining(), this.pending.size());
-        bytesWritten = bytesToWrite;
-
-        while (bytesToWrite > 0) {
-          this.outBuffer.put(this.pending.poll());
-          bytesToWrite--;
+    public void read(ByteBuffer b, SingleResultCallback<Integer> c) {
+        synchronized (buffer) {
+            //If nothing pending and the stream is still open, store the callback for future processing
+            if (buffer.isEmpty() && !closed) {
+                storeCallback(b, c);
+            } else {
+                doCallback(b, c);
+            }
         }
-      }
-
-      if (bytesWritten > 0) {
-        // if bytes were written call the callback
-
-        SingleResultCallback<Integer> tempCallback = this.callback;
-        this.outBuffer = null;
-        this.callback = null;
-        tempCallback.onResult(bytesWritten, null);
-
-      } else if (closed && this.pending.size() == 0) {
-        // if the stream has been closed and there is no more data to write available, send -1 to the callback
-
-        SingleResultCallback<Integer> tempCallback = this.callback;
-        this.outBuffer = null;
-        this.callback = null;
-        tempCallback.onResult(-1, null);
-      }
     }
 
-    // if there is a drain handler and the buffer is less than half full, call the drain handler
-    if (drainHandler != null && pending.size() < writeQueueMaxSize / 2) {
-      drainHandler.handle(null);
-      drainHandler = null;
+    private void storeCallback(final ByteBuffer b, final SingleResultCallback<Integer> c) {
+        if (pendingCallback != null && pendingCallback != c) {
+            c.onResult(null, new RuntimeException("mongo provided a new buffer or callback before the previous " +
+                    "one has been fulfilled"));
+        }
+        this.outputBuffer = b;
+        this.pendingCallback = c;
     }
-  }
+
+    private void doCallback(final ByteBuffer b, final SingleResultCallback<Integer> c) {
+        final int bytesWritten = buffer.drainInto(b);
+        c.onResult(bytesWritten, null);
+        // if there is a drain handler and the buffer is less than half full, call the drain handler
+        if (drainHandler != null && buffer.remaining() < writeQueueMaxSize / 2) {
+            drainHandler.handle(null);
+            drainHandler = null;
+        }
+        pendingCallback = null;
+        outputBuffer = null;
+    }
+
+    public WriteStream<Buffer> write(Buffer inputBuffer) {
+        if (closed) throw new IllegalStateException("Stream is closed");
+        final byte[] bytes = inputBuffer.getBytes();
+        final ByteBuffer wrapper = ByteBuffer.wrap(bytes);
+        synchronized (buffer) {
+            if (pendingCallback != null) {
+                int bytesWritten = writeOutput(wrapper);
+                if (bytesWritten > 0) doCallback(bytesWritten);
+            }
+        }
+        // Drain content left in the input buffer
+        buffer.fillFrom(wrapper);
+        return this;
+    }
+
+    private int writeOutput(final ByteBuffer wrapper) {
+        // First we drain the pending buffer
+        int bytesWritten = buffer.drainInto(outputBuffer);
+        final int remaining = outputBuffer.remaining();
+        if (remaining > 0) {
+            // If more space left in the output buffer we directly drain the input buffer
+            final int newBytesWritten = remaining > wrapper.capacity() ? wrapper.capacity() : remaining;
+            wrapper.limit(newBytesWritten);
+            outputBuffer.put(wrapper);
+            bytesWritten += newBytesWritten;
+        }
+        return bytesWritten;
+    }
+
+
+    private void doCallback(final int bytesWritten) {
+        SingleResultCallback<Integer> c = pendingCallback;
+        outputBuffer = null;
+        pendingCallback = null;
+        c.onResult(bytesWritten, null);
+    }
+
+    public void close(SingleResultCallback<Void> singleResultCallback) {
+        closed = true;
+        singleResultCallback.onResult(null, null);
+    }
+
+    public void end() {
+        synchronized (buffer) {
+            if (pendingCallback != null) {
+                final int bytesWritten = buffer.drainInto(outputBuffer);
+                doCallback(bytesWritten);
+            }
+            this.closed = true;
+        }
+    }
+
+    public WriteStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+        return this;
+    }
+
+    public GridFSInputStream setWriteQueueMaxSize(int i) {
+        writeQueueMaxSize = i;
+        return this;
+    }
+
+    public boolean writeQueueFull() {
+        return buffer.remaining() >= writeQueueMaxSize;
+    }
+
+    public WriteStream<Buffer> drainHandler(Handler<Void> handler) {
+        this.drainHandler = handler;
+        return this;
+    }
+
 }

--- a/src/main/java/com/github/sth/vertx/mongo/streams/util/CircularByteBuffer.java
+++ b/src/main/java/com/github/sth/vertx/mongo/streams/util/CircularByteBuffer.java
@@ -1,0 +1,98 @@
+package com.github.sth.vertx.mongo.streams.util;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <p>CircularByteBuffer class.</p> This class implements a simple unbounded circular byte
+ * buffer. The API accepts ByteBuffers as transfer object.
+ *
+ * @version $Id: $Id
+ */
+public final class CircularByteBuffer {
+
+    private byte[] array;
+    private int sizeMask;
+    private final AtomicInteger writeSequence = new AtomicInteger(0);
+    private final AtomicInteger readSequence = new AtomicInteger(0);
+
+    public CircularByteBuffer(int size) {
+        //Find the next power of two to allow bitwise masking. Double the requested size to avoid resizing mid processing.
+        size = nextPowerOfTwo(size);
+        array = new byte[size];
+        sizeMask = array.length - 1;
+    }
+
+    private int nextPowerOfTwo(int number) {
+        number = number - 1;
+        number |= number >> 1;
+        number |= number >> 2;
+        number |= number >> 4;
+        number |= number >> 8;
+        number |= number >> 16;
+        return number + 1;
+    }
+
+    public void fillFrom(ByteBuffer buffer) {
+        while (buffer.hasRemaining()) {
+            add(buffer.get());
+        }
+    }
+
+    private void add(byte value) {
+        ensureSize();
+        array[getIndex(writeSequence.getAndIncrement())] = value;
+    }
+
+    private void ensureSize() {
+        if (isFull()) {
+            final byte[] newArray = new byte[array.length << 1];
+            final int newSizeMask = newArray.length - 1;
+            final int readIndex = getIndex(readSequence.get());
+            final int unwrappedBytes = array.length - readIndex;
+            System.arraycopy(array, readIndex, newArray, 0, unwrappedBytes);
+            // If logically successive bytes are physically at the start of the array we need to append them in the new array
+            if (unwrappedBytes < array.length) {
+                System.arraycopy(array, 0, newArray, unwrappedBytes, readIndex);
+            }
+            readSequence.set(0);
+            writeSequence.set(array.length);
+            array = newArray;
+            sizeMask = newSizeMask;
+        }
+    }
+
+    public int drainInto(ByteBuffer byteBuffer) {
+        int byteWritten = 0;
+        while (readSequence.get() < writeSequence.get() && byteBuffer.hasRemaining()) {
+            byteBuffer.put(get());
+            byteWritten++;
+        }
+        return byteWritten;
+    }
+
+    private byte get() {
+        return array[getIndex(readSequence.getAndIncrement())];
+    }
+
+    private int getIndex(int sequence) {
+        return sequence & sizeMask;
+    }
+
+    public boolean isFull() {
+        return remaining() >= array.length;
+    }
+
+    public int remaining() {
+        return writeSequence.get() - readSequence.get();
+    }
+
+    public int capacity() {
+        return array.length;
+    }
+
+    public boolean isEmpty() {
+        return writeSequence.get() == readSequence.get();
+    }
+
+}

--- a/src/test/java/com/github/sth/vertx/mongo/streams/GridFSInputStreamTest.java
+++ b/src/test/java/com/github/sth/vertx/mongo/streams/GridFSInputStreamTest.java
@@ -1,14 +1,16 @@
 package com.github.sth.vertx.mongo.streams;
 
 import com.github.sth.vertx.mongo.streams.util.ByteUtil;
-import com.github.sth.vertx.mongo.streams.util.ResultCallback;
 import com.github.sth.vertx.mongo.streams.util.DrainHandler;
-import io.vertx.core.buffer.Buffer;
+import com.github.sth.vertx.mongo.streams.util.ResultCallback;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+
+import io.vertx.core.buffer.Buffer;
 
 public class GridFSInputStreamTest {
 
@@ -46,7 +48,7 @@ public class GridFSInputStreamTest {
     inputStream.read(byteBuffer, resultCallback);
 
     Assert.assertTrue(resultCallback.succeeded());
-    Assert.assertEquals(-1, resultCallback.getResult(), 0);
+    Assert.assertEquals(0, resultCallback.getResult(), 0);
   }
 
 
@@ -91,7 +93,7 @@ public class GridFSInputStreamTest {
     inputStream.end();
 
     Assert.assertTrue(resultCallback.succeeded());
-    Assert.assertEquals(-1, resultCallback.getResult(), 0);
+    Assert.assertEquals(0, resultCallback.getResult(), 0);
   }
 
 
@@ -168,15 +170,16 @@ public class GridFSInputStreamTest {
     GridFSInputStream inputStream = GridFSInputStream.create();
 
     ByteBuffer byteBuffer = ByteBuffer.allocate(2048);
-    ResultCallback<Integer> resultCallback = new ResultCallback<>();
-    inputStream.read(byteBuffer, resultCallback);
+    ResultCallback<Integer> resultCallback1 = new ResultCallback<>();
+    inputStream.read(byteBuffer, resultCallback1);
 
-    Assert.assertFalse(resultCallback.succeeded());
-    Assert.assertNull(resultCallback.getThrowable());
+    Assert.assertFalse(resultCallback1.succeeded());
+    Assert.assertNull(resultCallback1.getThrowable());
 
-    inputStream.read(byteBuffer, resultCallback);
-    Assert.assertFalse(resultCallback.succeeded());
-    Assert.assertEquals(RuntimeException.class, resultCallback.getThrowable().getClass());
+    ResultCallback<Integer> resultCallback2 = new ResultCallback<>();
+    inputStream.read(byteBuffer, resultCallback2);
+    Assert.assertFalse(resultCallback2.succeeded());
+    Assert.assertEquals(RuntimeException.class, resultCallback2.getThrowable().getClass());
   }
 
 

--- a/src/test/java/com/github/sth/vertx/mongo/streams/util/CircularByteBufferTest.java
+++ b/src/test/java/com/github/sth/vertx/mongo/streams/util/CircularByteBufferTest.java
@@ -1,0 +1,69 @@
+package com.github.sth.vertx.mongo.streams.util;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by antonio on 31/01/2017.
+ */
+public class CircularByteBufferTest {
+
+
+    @Test
+    public void fillAndDrainSucceeds() throws Exception {
+        CircularByteBuffer buffer = new CircularByteBuffer(10);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(10);
+        IntStream.range(0, 10).forEach(b -> byteBuffer.put((byte) b));
+        byteBuffer.flip();
+        buffer.fillFrom(byteBuffer);
+        byteBuffer.clear();
+        buffer.drainInto(byteBuffer);
+        byteBuffer.flip();
+        IntStream.range(0, 10).forEach(b -> assertEquals(b, byteBuffer.get()));
+        assertEquals(0, buffer.remaining());
+        assertEquals(16, buffer.capacity());
+    }
+
+    @Test
+    public void resizeSucceeds() throws Exception {
+        CircularByteBuffer buffer = new CircularByteBuffer(10);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(100);
+        IntStream.range(0, 100).forEach(b -> byteBuffer.put((byte) b));
+        byteBuffer.flip();
+        buffer.fillFrom(byteBuffer);
+        byteBuffer.clear();
+        buffer.drainInto(byteBuffer);
+        byteBuffer.flip();
+        IntStream.range(0, 100).forEach(b -> assertEquals(b, byteBuffer.get()));
+        assertEquals(0, buffer.remaining());
+        assertEquals(128, buffer.capacity());
+    }
+
+    @Test
+    public void resizeWhenWrappedSucceeds() throws Exception {
+        CircularByteBuffer buffer = new CircularByteBuffer(16);
+        ByteBuffer byteBuffer16 = ByteBuffer.allocate(16);
+        IntStream.range(0, 16).forEach(b -> byteBuffer16.put((byte) b));
+        byteBuffer16.flip();
+        buffer.fillFrom(byteBuffer16);
+        assertEquals(16, buffer.remaining());
+        byteBuffer16.clear();
+        ByteBuffer byteBuffer8 = ByteBuffer.allocate(8);
+        buffer.drainInto(byteBuffer8);
+        assertEquals(8, buffer.remaining());
+        ByteBuffer byteBuffer32 = ByteBuffer.allocate(32);
+        IntStream.range(16, 48).forEach(b -> byteBuffer32.put((byte) b));
+        byteBuffer32.flip();
+        buffer.fillFrom(byteBuffer32);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(40);
+        buffer.drainInto(byteBuffer);
+        byteBuffer.flip();
+        IntStream.range(8, 48).forEach(b -> assertEquals(b, byteBuffer.get()));
+        assertEquals(0, buffer.remaining());
+        assertEquals(64, buffer.capacity());
+    }
+}


### PR DESCRIPTION
Fix #5 
This will:
- Add a new primitive based circular buffer class
- Add basic tests for the circular buffer
- Replace the ArrayDeque with the new data structure
- Synchronize concurrent operations on the same lock to ensure visibility in filling/draining operations