### PR TITLE
replace vertx.runOnContext with context.runOnContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ mvn:
 ```
  <groupId>com.github.st-h</groupId>
  <artifactId>vertx-mongo-streams</artifactId>
- <version>2.0.0</version>
+ <version>2.0.1</version>
 ```
  
 gradle:
 ```
-com.github.st-h:vertx-mongo-streams:2.0.0
+com.github.st-h:vertx-mongo-streams:2.0.1
 ```
 
 ## Upgrading from 1.x
 
-The GridFSInputStream factory method `GridFSInputStream.create(vertx)` now requires the vertx instance as an argument. This is needed to ensure that the `drainHandler` of the vert.x `WriteStream` is called within the correct context. Please see [this blog post](http://vertx.io/blog/an-introduction-to-the-vert-x-context-object/) for details about the vert.x context.
+The GridFSInputStream factory method `GridFSInputStream.create(vertx)` now requires the vertx instance as an argument. This is needed to ensure that the `drainHandler` of the vert.x `WriteStream` is called within the correct context. When the constructor is invoked, the current vertx context is stored and will be restored when needed. Therefore one should not try to cache the GridFSInputStream instance. Please see [this blog post](http://vertx.io/blog/an-introduction-to-the-vert-x-context-object/) for details about the vert.x context.
 
 # Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.st-h</groupId>
     <artifactId>vertx-mongo-streams</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
 
     <name>Vert.x - MongoDB streams for the async MongoDB driver</name>
     <description>A stream helper to Pump data from a vert.x ReadStream (e.g. HttpServerFileUpload) to MongoDB AsyncInputStream.</description>

--- a/src/main/java/com/github/sth/vertx/mongo/streams/GridFSInputStream.java
+++ b/src/main/java/com/github/sth/vertx/mongo/streams/GridFSInputStream.java
@@ -32,6 +32,7 @@ public interface GridFSInputStream extends AsyncInputStream, WriteStream<Buffer>
     /**
      * Create a {@link com.github.sth.vertx.mongo.streams.GridFSInputStream}.
      *
+     * @param vertx the vertx instance
      * @return the stream
      */
     static GridFSInputStream create(Vertx vertx) {
@@ -41,6 +42,7 @@ public interface GridFSInputStream extends AsyncInputStream, WriteStream<Buffer>
     /**
      * Create a {@link com.github.sth.vertx.mongo.streams.GridFSInputStream}.
      *
+     * @param vertx the vertx instance
      * @param queueSize the initial queue size
      * @return the stream
      */


### PR DESCRIPTION
as we found out [here](https://groups.google.com/forum/#!topic/vertx/pey4EErJl1Y), making use of `vertx.runOnContext()` is not always safe. This PR replaces `vertx.runOnContext()`, with `context.runOnContext()` and stores the vertx context when invoking the constructor.